### PR TITLE
Naive updater script

### DIFF
--- a/update_duktape.sh
+++ b/update_duktape.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+SRC_LOCATION=duktape/src/main/jni/
+#Download the things
+wget -O duktape.tar.xz $(curl -s https://api.github.com/repos/svaarala/duktape/releases/latest | grep 'browser_' | cut -d\" -f4) 
+#Extract the release
+mkdir tmp
+tar xvfC duktape.tar.xz tmp/
+#Copy over the new sources
+cp -R tmp/duktape-*/src/ $SRC_LOCATION
+#Cleanup after ourselves
+rm duktape.tar.xz
+rm -r tmp


### PR DESCRIPTION
As mentioned in #16, a script to update duktape from upstream automatically.

I'm hardly a bash expert, so let me know if anything isn't kosher (like the use of `wget`, or the use of grep to pull the url from Github) and I can come up with another solution.

I did create #25 using it though, FWIW.

Edit: Now the script will patch `duk_config.h` to modify the timezone offset to use the java implementation from #17 

Edit 2: Now the script does less...because it doesn't have to patch anything.