### PR TITLE
Throw C++ exceptions for binding errors.

### DIFF
--- a/build_mac
+++ b/build_mac
@@ -13,4 +13,5 @@ g++ \
   duktape/src/main/jni/duktape.c \
   duktape/src/main/jni/duktape-jni.cpp \
   duktape/src/main/jni/DuktapeContext.cpp \
-  duktape/src/main/jni/JavaMethod.cpp
+  duktape/src/main/jni/JavaMethod.cpp \
+  duktape/src/main/jni/GlobalRef.cpp

--- a/duktape/build.gradle
+++ b/duktape/build.gradle
@@ -29,7 +29,7 @@ model {
       stl = "c++_static"
 
       CFlags.addAll(['-std=c99', '-fstrict-aliasing', '-DDUK_OPT_HAVE_CUSTOM_H'])
-      cppFlags.addAll(['-std=c++11', '-fstrict-aliasing', '-DDUK_OPT_HAVE_CUSTOM_H'])
+      cppFlags.addAll(['-std=c++11', '-fstrict-aliasing', '-fexceptions', '-DDUK_OPT_HAVE_CUSTOM_H'])
     }
   }
   android.lintOptions {

--- a/duktape/src/main/jni/GlobalRef.cpp
+++ b/duktape/src/main/jni/GlobalRef.cpp
@@ -43,6 +43,10 @@ GlobalRef::~GlobalRef() {
   getEnvFromJavaVM(m_javaVM)->DeleteGlobalRef(m_object);
 }
 
+JNIEnv* GlobalRef::getJniEnv() const {
+  return getEnvFromJavaVM(m_javaVM);
+}
+
 JNIEnv* getEnvFromJavaVM(JavaVM* javaVM) {
   if (javaVM == nullptr) {
     return nullptr;

--- a/duktape/src/main/jni/GlobalRef.h
+++ b/duktape/src/main/jni/GlobalRef.h
@@ -33,6 +33,8 @@ public:
     return m_object;
   }
 
+  JNIEnv* getJniEnv() const;
+
 private:
   JavaVM* m_javaVM;
   jobject m_object;

--- a/duktape/src/main/jni/JString.h
+++ b/duktape/src/main/jni/JString.h
@@ -16,6 +16,9 @@
 #ifndef DUKTAPE_ANDROID_JSTRING_H
 #define DUKTAPE_ANDROID_JSTRING_H
 
+#include <string>
+#include <jni.h>
+
 class JString {
 public:
   JString(JNIEnv* env, jstring s)
@@ -29,6 +32,10 @@ public:
   }
 
   operator const char* () const {
+    return m_str;
+  }
+
+  std::string str() const {
     return m_str;
   }
 

--- a/tests/src/androidTest/java/com/squareup/duktape/DuktapeTest.java
+++ b/tests/src/androidTest/java/com/squareup/duktape/DuktapeTest.java
@@ -127,6 +127,24 @@ public final class DuktapeTest {
     }
   }
 
+  @Test public void bindSameNameTwiceFails() {
+    duktape.bind("value", TestInterface.class, new TestInterface() {
+      @Override public String getValue() {
+        return "foo";
+      }
+    });
+    try {
+      duktape.bind("value", TestInterface.class, new TestInterface() {
+        @Override public String getValue() {
+          return "bar";
+        }
+      });
+      fail();
+    } catch (IllegalArgumentException expected) {
+      assertThat(expected).hasMessage("A global object called value already exists");
+    }
+  }
+
   interface TestInterfaceArgs {
     String foo(String a, String b, String c);
   }


### PR DESCRIPTION
- Exceptions are translated to Java exceptions and rethrown to the Java caller.
- Make sure objects and memory are freed up when bad things happen.