### PR TITLE
Add unit tests to validate bind failure messages.

### DIFF
--- a/duktape/src/main/jni/DuktapeContext.cpp
+++ b/duktape/src/main/jni/DuktapeContext.cpp
@@ -23,7 +23,7 @@
 
 namespace {
 
-// Internal names used for properties in the duktape context's global stash and bound variables.
+// Internal names used for properties in the Duktape context's global stash and bound variables.
 // The \xff\xff part keeps the variable hidden from JavaScript (visible through C API only).
 const char* JAVA_VM_PROP_NAME = "\xff\xffjavaVM";
 const char* JAVA_THIS_PROP_NAME = "\xff\xffjava_this";
@@ -60,7 +60,7 @@ duk_int_t eval_string_with_filename(duk_context *ctx, const char *src, const cha
                                    DUK_COMPILE_NOSOURCE | DUK_COMPILE_STRLEN);
 }
 
-// Called by duktape when JS invokes a method on our bound Java object.
+// Called by Duktape when JS invokes a method on our bound Java object.
 duk_ret_t javaMethodHandler(duk_context *ctx) {
   JavaMethod* method = getJavaMethod(ctx);
   return method != nullptr
@@ -68,16 +68,14 @@ duk_ret_t javaMethodHandler(duk_context *ctx) {
          : DUK_RET_INTERNAL_ERROR;
 }
 
-// Called by duktape to handle finalization of bound Java objects.
+// Called by Duktape to handle finalization of bound Java objects.
 duk_ret_t javaObjectFinalizer(duk_context *ctx) {
-  if (!duk_get_prop_string(ctx, -1, JAVA_THIS_PROP_NAME)) {
-    return DUK_RET_INTERNAL_ERROR;
+  if (duk_get_prop_string(ctx, -1, JAVA_THIS_PROP_NAME)) {
+    // Remove the global reference from the bound Java object.
+    getJNIEnv(ctx)->DeleteGlobalRef(static_cast<jobject>(duk_require_pointer(ctx, -1)));
+    duk_pop(ctx);
+    duk_del_prop_string(ctx, -1, JAVA_METHOD_PROP_NAME);
   }
-
-  // Remove the global reference from the bound java object.
-  getJNIEnv(ctx)->DeleteGlobalRef(static_cast<jobject>(duk_require_pointer(ctx, -1)));
-  duk_pop(ctx);
-  duk_del_prop_string(ctx, -1, JAVA_METHOD_PROP_NAME);
 
   // Iterate over all of the properties, deleting all the JavaMethod objects we attached.
   duk_enum(ctx, -1, DUK_ENUM_OWN_PROPERTIES_ONLY);
@@ -103,7 +101,7 @@ DuktapeContext::DuktapeContext(JavaVM* javaVM)
     throw std::bad_alloc();
   }
 
-  // Stash the JVM object in the context, so we can find our way back from a duktape C callback.
+  // Stash the JVM object in the context, so we can find our way back from a Duktape C callback.
   duk_push_global_stash(m_context);
   duk_push_pointer(m_context, javaVM);
   duk_put_prop_string(m_context, -2, JAVA_VM_PROP_NAME);
@@ -123,13 +121,13 @@ jstring DuktapeContext::evaluate(JNIEnv *env, jstring code, jstring fname) {
   if (eval_string_with_filename(m_context, sourceCode, fileName) != 0) {
     jclass exceptionClass = env->FindClass("com/squareup/duktape/DuktapeException");
 
-    // If it's a duktape error object, try to pull out the full stacktrace.
+    // If it's a Duktape error object, try to pull out the full stacktrace.
     if (duk_is_error(m_context, -1) && duk_get_prop_string(m_context, -1, "stack")) {
       const char* stack = duk_safe_to_string(m_context, -1);
 
       // Is there an exception thrown from a Java method?
       if (duk_get_prop_string(m_context, -2, JavaMethod::JAVA_EXCEPTION_PROP_NAME)) {
-        // TODO: add the duktape stack to this exception.
+        // TODO: add the Duktape stack to this exception.
         jthrowable ex = static_cast<jthrowable>(duk_get_pointer(m_context, -1));
         env->Throw(ex);
         duk_pop(m_context);
@@ -162,10 +160,6 @@ void DuktapeContext::bindInstance(JNIEnv *env, jstring name, jobject object, job
   }
   const duk_idx_t objIndex = duk_require_normalize_index(m_context, duk_push_object(m_context));
 
-  // Keep a reference in JavaScript to the object being bound.
-  duk_push_pointer(m_context, env->NewGlobalRef(object));
-  duk_put_prop_string(m_context, objIndex, JAVA_THIS_PROP_NAME);
-
   // Hook up a finalizer to decrement the refcount and clean up our JavaMethods.
   duk_push_c_function(m_context, javaObjectFinalizer, 1);
   duk_set_finalizer(m_context, objIndex);
@@ -192,7 +186,7 @@ void DuktapeContext::bindInstance(JNIEnv *env, jstring name, jobject object, job
     }
 
     // Use VARARGS here to allow us to manually validate that the proper number of arguments are
-    // given in the call.  If we specify the actual number of arguments needed, duktape will try to
+    // given in the call.  If we specify the actual number of arguments needed, Duktape will try to
     // be helpful by discarding extra or providing missing arguments. That's not quite what we want.
     // See http://duktape.org/api.html#duk_push_c_function for details.
     const duk_idx_t func = duk_push_c_function(m_context, javaMethodHandler, DUK_VARARGS);
@@ -203,8 +197,12 @@ void DuktapeContext::bindInstance(JNIEnv *env, jstring name, jobject object, job
     duk_put_prop_string(m_context, objIndex, methodName);
   }
 
-  // Make our bound java object a property of the duktape global object (so it's a JS global).
+  // Keep a reference in JavaScript to the object being bound.
+  duk_push_pointer(m_context, env->NewGlobalRef(object));
+  duk_put_prop_string(m_context, objIndex, JAVA_THIS_PROP_NAME);
+
+  // Make our bound Java object a property of the Duktape global object (so it's a JS global).
   duk_put_prop_string(m_context, -2, instanceName);
-  // Pop the duktape global object off the stack.
+  // Pop the Duktape global object off the stack.
   duk_pop(m_context);
 }

--- a/duktape/src/main/jni/GlobalRef.h
+++ b/duktape/src/main/jni/GlobalRef.h
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef DUKTAPE_ANDROID_SCOPEDGLOBALREF_H
-#define DUKTAPE_ANDROID_SCOPEDGLOBALREF_H
+#ifndef DUKTAPE_ANDROID_GLOBALREF_H
+#define DUKTAPE_ANDROID_GLOBALREF_H
 
 #include <jni.h>
 
@@ -42,4 +42,4 @@ private:
 
 JNIEnv* getEnvFromJavaVM(JavaVM* javaVM);
 
-#endif //DUKTAPE_ANDROID_SCOPEDGLOBALREF_H
+#endif //DUKTAPE_ANDROID_GLOBALREF_H

--- a/duktape/src/main/jni/JavaMethod.cpp
+++ b/duktape/src/main/jni/JavaMethod.cpp
@@ -57,7 +57,7 @@ duk_ret_t JavaMethod::invoke(duk_context* ctx, JNIEnv* env, jobject javaThis) co
   }
 
   std::vector<jvalue> args(m_argumentLoaders.size());
-  // Load the arguments off the stack and convert to java types.
+  // Load the arguments off the stack and convert to Java types.
   // Note we're going backwards since the last argument is at the top of the stack.
   for (ssize_t i = m_argumentLoaders.size() - 1; i >= 0; --i) {
     args[i] = m_argumentLoaders[i](ctx, env);
@@ -185,11 +185,11 @@ JavaMethod::ArgumentLoader getArgumentLoader(JNIEnv *env, jobject typeObject) {
     };
   }
 
-  throw std::invalid_argument("Unable to marshal " + toString(env, typeObject));
+  throw std::invalid_argument("Unsupported parameter type " + toString(env, typeObject));
 }
 
 /**
- * Determines if an exception has been thrown in this JNI thread.  If so, creates a duktape error
+ * Determines if an exception has been thrown in this JNI thread.  If so, creates a Duktape error
  * with the Java exception embedded in it, and throws it.
  */
 void checkRethrowException(duk_context* ctx, JNIEnv* env) {
@@ -218,7 +218,7 @@ duk_ret_t unboxAndPushPrimitive(duk_context* ctx, JNIEnv* jniEnv,
 /**
  * Returns a functor that will invoke the proper JNI function to get the matching {@code returnType}
  * and convert the result to a JS type then push it to the stack.  The functor returns the number
- * of entries pushed to the stack to be returned to the duktape caller.
+ * of entries pushed to the stack to be returned to the Duktape caller.
  */
 JavaMethod::MethodBody getMethodBody(JNIEnv* env, jmethodID methodId, jobject returnType) {
   if (env->IsSameObject(returnType, env->FindClass("java/lang/String"))) {
@@ -291,7 +291,7 @@ JavaMethod::MethodBody getMethodBody(JNIEnv* env, jmethodID methodId, jobject re
     };
   }
 
-  throw std::invalid_argument("Unable to unmarshal " + toString(env, returnType));
+  throw std::invalid_argument("Unsupported return type " + toString(env, returnType));
 }
 
 } // anonymous namespace

--- a/duktape/src/main/jni/JavaMethod.h
+++ b/duktape/src/main/jni/JavaMethod.h
@@ -24,7 +24,7 @@
 class JavaMethod {
 public:
   /**
-   * Internal name used for storing a thrown Java exception as a property of a duktape error object.
+   * Internal name used for storing a thrown Java exception as a property of a Duktape error object.
    * The \xff\xff part keeps the variable hidden from JavaScript (visible through C API only).
    */
   static constexpr const char* JAVA_EXCEPTION_PROP_NAME = "\xff\xffjava_exception";
@@ -33,20 +33,20 @@ public:
 
   /**
    * Invokes this method using {@code javaThis}, with the arguments on the stack given in {@ctx}.
-   * Returns the number of results pushed to the duktape stack, or a negative status code.
+   * Returns the number of results pushed to the Duktape stack, or a negative status code.
    */
   duk_ret_t invoke(duk_context *ctx, JNIEnv *env, jobject javaThis) const;
 
   /**
-   * Defines a functor to use to pop a value off the duktape stack and convert it to the required
+   * Defines a functor to use to pop a value off the Duktape stack and convert it to the required
    * Java type.
    */
   typedef std::function<jvalue(duk_context*, JNIEnv*)> ArgumentLoader;
   /**
    * Defines a functor to invoke the correct JNI method that will return the required Java type,
-   * convert the return value to a JavaScript type and push it to the duktape stack.  Returns the
+   * convert the return value to a JavaScript type and push it to the Duktape stack.  Returns the
    * number of entries pushed to the stack.
-   * If the Java method throws an exception, the functor will throw a duktape error with the
+   * If the Java method throws an exception, the functor will throw a Duktape error with the
    * exception inside.
    */
   typedef std::function<duk_ret_t(duk_context*, JNIEnv*, jobject, jvalue*)> MethodBody;


### PR DESCRIPTION
- C++ code enforces supported argument/return types
- Some misc suggested comment cleanup