### PR TITLE
Coerce values returned from evaluate to string.

### DIFF
--- a/duktape/src/main/jni/DuktapeContext.cpp
+++ b/duktape/src/main/jni/DuktapeContext.cpp
@@ -150,8 +150,9 @@ jstring DuktapeContext::evaluate(JNIEnv *env, jstring code, jstring fname) {
       // Not an error or no stacktrace, just convert to a string.
       env->ThrowNew(exceptionClass, duk_safe_to_string(m_context, -1));
     }
-  } else {
-    result = env->NewStringUTF(duk_get_string(m_context, -1));
+  } else if (!duk_is_null_or_undefined(m_context, -1)) {
+    // Return a string result (coerce the value if needed).
+    result = env->NewStringUTF(duk_safe_to_string(m_context, -1));
   }
 
   // Pop the result of the evaluate call.

--- a/tests/src/androidTest/java/com/squareup/duktape/DuktapeTest.java
+++ b/tests/src/androidTest/java/com/squareup/duktape/DuktapeTest.java
@@ -45,6 +45,11 @@ public final class DuktapeTest {
     assertThat(hello).isEqualTo("HELLO, WORLD!");
   }
 
+  @Test public void evaluateReturnsNumber() {
+    String result = duktape.evaluate("2 + 3;");
+    assertThat(result).isEqualTo("5");
+  }
+
   @Test public void exceptionsInScriptThrowInJava() {
     try {
       duktape.evaluate("nope();");


### PR DESCRIPTION
- but continue to treat null or undefined as Java null.