### PR TITLE
Create JavaScriptObject to proxy a JS global.

### DIFF
--- a/build_mac
+++ b/build_mac
@@ -14,4 +14,6 @@ g++ \
   duktape/src/main/jni/duktape-jni.cpp \
   duktape/src/main/jni/DuktapeContext.cpp \
   duktape/src/main/jni/JavaMethod.cpp \
+  duktape/src/main/jni/JavaExceptions.cpp \
+  duktape/src/main/jni/JavaScriptObject.cpp \
   duktape/src/main/jni/GlobalRef.cpp

--- a/duktape/src/main/java/com/squareup/duktape/Duktape.java
+++ b/duktape/src/main/java/com/squareup/duktape/Duktape.java
@@ -118,24 +118,25 @@ public final class Duktape implements Closeable {
       }
     }
 
-    final Object instance = proxy(context, name, methods.values().toArray());
+    final long instance = proxy(context, name, methods.values().toArray());
 
-    return (T) Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[]{ type },
+    Object proxy = Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[]{ type },
         new InvocationHandler() {
-      @Override
-      public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-        // If the method is a method from Object then defer to normal invocation.
-        if (method.getDeclaringClass() == Object.class) {
-          return method.invoke(this, args);
-        }
-        return call(context, instance, method, args);
-      }
+          @Override
+          public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+            // If the method is a method from Object then defer to normal invocation.
+            if (method.getDeclaringClass() == Object.class) {
+              return method.invoke(this, args);
+            }
+            return call(context, instance, method, args);
+          }
 
-      @Override
-      public String toString() {
-        return String.format("DuktapeProxy{name=%s, type=%s}", name, type.getName());
-      }
-    });
+          @Override
+          public String toString() {
+            return String.format("DuktapeProxy{name=%s, type=%s}", name, type.getName());
+          }
+        });
+    return (T) proxy;
   }
 
   /**
@@ -160,8 +161,8 @@ public final class Duktape implements Closeable {
   private static native void destroyContext(long context);
   private static native String evaluate(long context, String sourceCode, String fileName);
   private static native void bind(long context, String name, Object object, Object[] methods);
-  private static native Object proxy(long context, String name, Object[] methods);
-  private static native Object call(long context, Object instance, Object method, Object[] args);
+  private static native long proxy(long context, String name, Object[] methods);
+  private static native Object call(long context, long instance, Object method, Object[] args);
 
   /** Returns the timezone offset in seconds given system time millis. */
   @SuppressWarnings("unused") // Called from native code.

--- a/duktape/src/main/jni/DuktapeContext.h
+++ b/duktape/src/main/jni/DuktapeContext.h
@@ -17,7 +17,10 @@
 #define DUKTAPE_ANDROID_DUKTAPE_CONTEXT_H
 
 #include <jni.h>
+#include <vector>
 #include "duktape.h"
+
+class JavaScriptObject;
 
 class DuktapeContext {
 public:
@@ -30,12 +33,13 @@ public:
 
   void bind(JNIEnv* env, jstring name, jobject object, jobjectArray methods);
 
-  jobject proxy(JNIEnv* env, jstring name, jobjectArray methods);
+  jlong proxy(JNIEnv* env, jstring name, jobjectArray methods);
 
-  jobject call(JNIEnv* env, jobject instance, jobject method, jobjectArray args);
+  jobject call(JNIEnv* env, jlong instance, jobject method, jobjectArray args);
 
 private:
   duk_context* m_context;
+  std::vector<JavaScriptObject*> m_proxiedObjects;
 };
 
 #endif // DUKTAPE_ANDROID_DUKTAPE_CONTEXT_H

--- a/duktape/src/main/jni/GlobalRef.cpp
+++ b/duktape/src/main/jni/GlobalRef.cpp
@@ -25,7 +25,7 @@ GlobalRef::GlobalRef(const GlobalRef& other)
     , m_object(getEnvFromJavaVM(m_javaVM)->NewGlobalRef(other.m_object)) {
 }
 
-GlobalRef& GlobalRef::operator=(GlobalRef& other) {
+GlobalRef& GlobalRef::operator=(const GlobalRef& other) {
   if (&other != this) {
     // Increment the new reference before decrementing the old.
     auto oldJVM = m_javaVM;

--- a/duktape/src/main/jni/GlobalRef.h
+++ b/duktape/src/main/jni/GlobalRef.h
@@ -26,7 +26,7 @@ class GlobalRef {
 public:
   GlobalRef(JNIEnv* env, jobject object);
   GlobalRef(const GlobalRef& other);
-  GlobalRef& operator=(GlobalRef& other);
+  GlobalRef& operator=(const GlobalRef& other);
   ~GlobalRef();
 
   jobject get() const {

--- a/duktape/src/main/jni/JavaExceptions.cpp
+++ b/duktape/src/main/jni/JavaExceptions.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "JavaExceptions.h"
+
+namespace {
+
+/**
+ * Internal name used for storing a thrown Java exception as a property of a Duktape error object.
+ * The \xff\xff part keeps the variable hidden from JavaScript (visible through C API only).
+ */
+const char* JAVA_EXCEPTION_PROP_NAME = "\xff\xffjava_exception";
+
+} // anonymous namespace
+
+void queueIllegalArgumentException(JNIEnv* env, const std::string& message) {
+  const jclass illegalArgumentException = env->FindClass("java/lang/IllegalArgumentException");
+  env->ThrowNew(illegalArgumentException, message.c_str());
+}
+
+void queueDuktapeException(JNIEnv* env, const std::string& message) {
+  const jclass exceptionClass = env->FindClass("com/squareup/duktape/DuktapeException");
+  env->ThrowNew(exceptionClass, message.c_str());
+}
+
+void queueNullPointerException(JNIEnv* env, const std::string& message) {
+  jclass exceptionClass = env->FindClass("java/lang/NullPointerException");
+  env->ThrowNew(exceptionClass, message.c_str());
+}
+
+void checkRethrowDuktapeError(JNIEnv* env, duk_context* ctx) {
+  if (!env->ExceptionCheck()) {
+    return;
+  }
+
+  // The Java call threw an exception - it should be propagated back through JavaScript.
+  duk_push_error_object(ctx, DUK_ERR_API_ERROR, "Java Exception");
+  duk_push_pointer(ctx, env->ExceptionOccurred());
+  env->ExceptionClear();
+  duk_put_prop_string(ctx, -2, JAVA_EXCEPTION_PROP_NAME);
+  duk_throw(ctx);
+}
+
+void queueJavaExceptionForDuktapeError(JNIEnv *env, duk_context *ctx) {
+  jclass exceptionClass = env->FindClass("com/squareup/duktape/DuktapeException");
+
+  // If it's a Duktape error object, try to pull out the full stacktrace.
+  if (duk_is_error(ctx, -1) && duk_get_prop_string(ctx, -1, "stack")) {
+    const char* stack = duk_safe_to_string(ctx, -1);
+
+    // Is there an exception thrown from a Java method?
+    if (duk_get_prop_string(ctx, -2, JAVA_EXCEPTION_PROP_NAME)) {
+      jthrowable ex = static_cast<jthrowable>(duk_get_pointer(ctx, -1));
+
+      // add the Duktape JavaScript stack to this exception.
+      const jmethodID addDuktapeStack =
+          env->GetStaticMethodID(exceptionClass,
+                                 "addDuktapeStack",
+                                 "(Ljava/lang/Throwable;Ljava/lang/String;)V");
+      env->CallStaticVoidMethod(exceptionClass, addDuktapeStack, ex, env->NewStringUTF(stack));
+
+      // Rethrow the Java exception.
+      env->Throw(ex);
+
+      // Pop the Java throwable.
+      duk_pop(ctx);
+    } else {
+      env->ThrowNew(exceptionClass, stack);
+    }
+    // Pop the stack text.
+    duk_pop(ctx);
+  } else {
+    // Not an error or no stacktrace, just convert to a string.
+    env->ThrowNew(exceptionClass, duk_safe_to_string(ctx, -1));
+  }
+}

--- a/duktape/src/main/jni/JavaExceptions.h
+++ b/duktape/src/main/jni/JavaExceptions.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef DUKTAPE_ANDROID_JAVAEXCEPTIONS_H
+#define DUKTAPE_ANDROID_JAVAEXCEPTIONS_H
+
+#include <jni.h>
+#include "duktape.h"
+#include <string>
+
+void queueIllegalArgumentException(JNIEnv* env, const std::string& message);
+
+void queueDuktapeException(JNIEnv* env, const std::string& message);
+
+void queueNullPointerException(JNIEnv* env, const std::string& message);
+
+/**
+ * Determines if an exception has been thrown in this JNI thread.  If so, creates a Duktape error
+ * with the Java exception embedded in it, and throws it.
+ */
+void checkRethrowDuktapeError(JNIEnv *env, duk_context *ctx);
+
+/**
+ * Sets up a Java {@code DuktapeException} based on the Duktape JavaScript error at the top of the
+ * Duktape stack. The exception will be thrown to the Java caller when the current JNI call returns.
+ */
+void queueJavaExceptionForDuktapeError(JNIEnv *env, duk_context *ctx);
+
+#endif //DUKTAPE_ANDROID_JAVAEXCEPTIONS_H

--- a/duktape/src/main/jni/JavaMethod.h
+++ b/duktape/src/main/jni/JavaMethod.h
@@ -23,12 +23,6 @@
 
 class JavaMethod {
 public:
-  /**
-   * Internal name used for storing a thrown Java exception as a property of a Duktape error object.
-   * The \xff\xff part keeps the variable hidden from JavaScript (visible through C API only).
-   */
-  static constexpr const char* JAVA_EXCEPTION_PROP_NAME = "\xff\xffjava_exception";
-
   JavaMethod(JNIEnv* env, jobject method);
 
   /**

--- a/duktape/src/main/jni/JavaScriptObject.cpp
+++ b/duktape/src/main/jni/JavaScriptObject.cpp
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "JavaScriptObject.h"
+#include <stdexcept>
+#include "JString.h"
+#include "JavaExceptions.h"
+
+// TODO: debug instance tracking issues so we don't need to lookup by name on a call.
+#define NO_INSTANCE_VAR
+
+namespace {
+
+// Internal names used for properties in a proxied JavaScript object.
+// The \xff\xff part keeps the variable hidden from JavaScript (visible through C API only).
+const char* WRAPPER_THIS_PROP_NAME = "\xff\xffwrapper_this";
+
+}
+
+JavaScriptObject::JavaScriptObject(JNIEnv* env, duk_context* context, const std::string& name,
+                                   jobjectArray methods)
+    : m_name(name)
+    , m_context(context)
+    , m_instance(nullptr)
+    , m_nextFinalizer(nullptr) {
+  duk_push_global_object(m_context);
+  if (!duk_get_prop_string(m_context, -1, m_name.c_str())) {
+    duk_pop(m_context);
+    throw std::invalid_argument("A global JavaScript object called " + m_name + " was not found");
+  }
+
+#ifdef NO_INSTANCE_VAR
+  if (!duk_is_object(m_context, -1)) {
+#else
+  m_instance = duk_get_heapptr(m_context, -1);
+  if (m_instance == nullptr) {
+#endif
+    duk_pop_2(m_context);
+    throw std::invalid_argument("JavaScript global called " + m_name + " is not an object");
+  }
+
+  // Make sure that the object has all of the methods we want.
+  jmethodID getName = nullptr;
+  const jsize numArgs = env->GetArrayLength(methods);
+  for (jsize i = 0; i < numArgs; ++i) {
+    auto method = env->GetObjectArrayElement(methods, i);
+    if (getName == nullptr) {
+      jclass methodClass = env->GetObjectClass(method);
+      getName = env->GetMethodID(methodClass, "getName", "()Ljava/lang/String;");
+    }
+
+    const JString methodName(env, static_cast<jstring>(env->CallObjectMethod(method, getName)));
+    if (!duk_get_prop_string(m_context, -1, methodName)) {
+      duk_pop_2(m_context);
+      throw std::runtime_error("JavaScript global " + m_name + " has no method called " +
+          methodName.str());
+    } else if (!duk_is_callable(m_context, -1)) {
+      duk_pop_3(m_context);
+      throw std::runtime_error("JavaScript property " + m_name + "." + methodName.str() +
+          " not callable");
+    }
+
+    // TODO: build a call wrapper that handles marshalling the arguments and return value.
+    //       Store it in this object.
+
+    // Pop the method property.
+    duk_pop(m_context);
+  }
+
+#ifndef NO_INSTANCE_VAR
+  // Keep track of any previously registered finalizer.
+  duk_get_finalizer(m_context, -1);
+  m_nextFinalizer = duk_is_c_function(m_context, -1)
+     ? duk_get_c_function(m_context, -1)
+     : nullptr;
+  duk_pop(m_context);
+  duk_push_c_function(m_context, JavaScriptObject::finalizer, 1);
+  duk_set_finalizer(m_context, -2);
+#endif
+
+  duk_push_pointer(m_context, this);
+  duk_put_prop_string(m_context, -2, WRAPPER_THIS_PROP_NAME);
+
+  // Pop the global and our instance.
+  duk_pop_2(m_context);
+}
+
+JavaScriptObject::~JavaScriptObject() {
+  if (m_instance) {
+    // The instance still exists - detach from it.
+    duk_push_heapptr(m_context, m_instance);
+    duk_del_prop_string(m_context, -1, WRAPPER_THIS_PROP_NAME);
+
+    // Reset to the object's previous finalizer.
+    duk_push_c_function(m_context, m_nextFinalizer, 1);
+    duk_set_finalizer(m_context, -2);
+    duk_pop(m_context);
+  }
+}
+
+jobject JavaScriptObject::call(JNIEnv* env, jobject method, jobjectArray args) {
+#ifdef NO_INSTANCE_VAR
+  duk_push_global_object(m_context);
+  if (!duk_get_prop_string(m_context, -1, m_name.c_str())) {
+    duk_pop(m_context);
+    queueNullPointerException(env, "JavaScript object called " + m_name + " was not found");
+    return nullptr;
+  }
+#else
+  if (m_instance == nullptr) {
+    queueNullPointerException(env, "JavaScript object " + m_name + " has been garbage collected");
+    return nullptr;
+  }
+  duk_push_heapptr(m_context, m_instance);
+#endif
+
+  jclass methodClass = env->GetObjectClass(method);
+
+  const jmethodID getName = env->GetMethodID(methodClass, "getName", "()Ljava/lang/String;");
+  const JString methodName(env, static_cast<jstring>(env->CallObjectMethod(method, getName)));
+  duk_push_string(m_context, methodName);
+
+  // TODO: put the arguments (from args) on the stack too.
+
+  jobject result;
+  if (duk_pcall_prop(m_context, -2, 0) == DUK_EXEC_SUCCESS) {
+    // TODO: handle other return types.
+    result = duk_is_null_or_undefined(m_context, -1)
+        ? nullptr
+        : env->NewStringUTF(duk_safe_to_string(m_context, -1));
+  } else {
+    queueJavaExceptionForDuktapeError(env, m_context);
+    result = nullptr;
+  }
+
+  // Pop our instance and the call's result or error.
+  duk_pop_3(m_context);
+
+  return result;
+}
+
+duk_ret_t JavaScriptObject::finalizer(duk_context* ctx) {
+  if (!duk_get_prop_string(ctx, -1, WRAPPER_THIS_PROP_NAME)) {
+    return 0;
+  }
+
+  JavaScriptObject* obj = reinterpret_cast<JavaScriptObject*>(duk_require_pointer(ctx, -1));
+  duk_pop(ctx);
+
+  duk_del_prop_string(ctx, -1, WRAPPER_THIS_PROP_NAME);
+
+  // Null out the instance pointer - it's been garbage collected!
+  obj->m_instance = nullptr;
+
+  if (obj->m_nextFinalizer) {
+    // Continue with the next finalizer in the chain.
+    obj->m_nextFinalizer(ctx);
+  }
+  return 0;
+}

--- a/duktape/src/main/jni/JavaScriptObject.h
+++ b/duktape/src/main/jni/JavaScriptObject.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef DUKTAPE_ANDROID_JAVASCRIPTOBJECT_H
+#define DUKTAPE_ANDROID_JAVASCRIPTOBJECT_H
+
+#include <string>
+#include <jni.h>
+#include "duktape.h"
+
+/** The class represents a global JavaScript object that can be called from Java. */
+class JavaScriptObject {
+public:
+  JavaScriptObject(JNIEnv* env, duk_context* context, const std::string& name, jobjectArray methods);
+  ~JavaScriptObject();
+  JavaScriptObject(const JavaScriptObject&) = delete;
+  JavaScriptObject& operator=(const JavaScriptObject&) = delete;
+
+  jobject call(JNIEnv* env, jobject method, jobjectArray args);
+
+  const std::string& name() const {
+    return m_name;
+  }
+
+private:
+  static duk_ret_t finalizer(duk_context* ctx);
+
+  const std::string m_name;
+  duk_context* m_context;
+  void* m_instance;
+  duk_c_function m_nextFinalizer;
+};
+
+
+#endif //DUKTAPE_ANDROID_JAVASCRIPTOBJECT_H

--- a/duktape/src/main/jni/duktape-jni.cpp
+++ b/duktape/src/main/jni/duktape-jni.cpp
@@ -65,7 +65,7 @@ Java_com_squareup_duktape_Duktape_createContext(JNIEnv* env, jclass type) {
 
 JNIEXPORT void JNICALL
 Java_com_squareup_duktape_Duktape_destroyContext(JNIEnv *env, jclass type, jlong context) {
-  delete reinterpret_cast<DuktapeContext *>(context);
+  delete reinterpret_cast<DuktapeContext*>(context);
 }
 
 JNIEXPORT jstring JNICALL
@@ -79,8 +79,8 @@ Java_com_squareup_duktape_Duktape_evaluate__JLjava_lang_String_2Ljava_lang_Strin
 }
 
 JNIEXPORT void JNICALL
-Java_com_squareup_duktape_Duktape_bind__JLjava_lang_String_2Ljava_lang_Object_2_3Ljava_lang_Object_2(
-    JNIEnv *env, jclass type, jlong context, jstring name, jobject object, jobjectArray methods) {
+Java_com_squareup_duktape_Duktape_bind(JNIEnv *env, jclass type, jlong context, jstring name,
+                                       jobject object, jobjectArray methods) {
   DuktapeContext* duktape = reinterpret_cast<DuktapeContext*>(context);
   if (throwIfNull(env, duktape)) {
     return;
@@ -88,24 +88,24 @@ Java_com_squareup_duktape_Duktape_bind__JLjava_lang_String_2Ljava_lang_Object_2_
   duktape->bind(env, name, object, methods);
 }
 
-JNIEXPORT jobject JNICALL
+JNIEXPORT jlong JNICALL
 Java_com_squareup_duktape_Duktape_proxy(JNIEnv *env, jclass type, jlong context, jstring name,
                                         jobjectArray methods) {
   DuktapeContext* duktape = reinterpret_cast<DuktapeContext*>(context);
   if (throwIfNull(env, duktape)) {
-    return nullptr;
+    return -1L;
   }
   return duktape->proxy(env, name, methods);
 }
 
 JNIEXPORT jobject JNICALL
-Java_com_squareup_duktape_Duktape_call(JNIEnv *env, jclass type, jlong context, jobject target,
+Java_com_squareup_duktape_Duktape_call(JNIEnv *env, jclass type, jlong context, jlong instance,
                                        jobject method, jobjectArray args) {
   DuktapeContext* duktape = reinterpret_cast<DuktapeContext*>(context);
   if (throwIfNull(env, duktape)) {
     return nullptr;
   }
-  return duktape->call(env, target, method, args);
+  return duktape->call(env, instance, method, args);
 }
 
 } // extern "C"


### PR DESCRIPTION
- Allows us to (hopefully) bind to the instance, rather than just the name (still a WIP).
- Allows us to wrap methods early & cache them like we do when binding a Java object.