### PR TITLE
JavaScript proxy support for more argument types.

### DIFF
--- a/duktape/src/main/jni/DuktapeContext.h
+++ b/duktape/src/main/jni/DuktapeContext.h
@@ -17,10 +17,9 @@
 #define DUKTAPE_ANDROID_DUKTAPE_CONTEXT_H
 
 #include <jni.h>
-#include <vector>
+#include <list>
 #include "duktape.h"
-
-class JavaScriptObject;
+#include "JavaScriptObject.h"
 
 class DuktapeContext {
 public:
@@ -29,17 +28,15 @@ public:
   DuktapeContext(const DuktapeContext &) = delete;
   DuktapeContext & operator=(const DuktapeContext &) = delete;
 
-  jstring evaluate(JNIEnv* env, jstring sourceCode, jstring fileName);
+  jstring evaluate(JNIEnv* env, jstring sourceCode, jstring fileName) const;
 
   void bind(JNIEnv* env, jstring name, jobject object, jobjectArray methods);
 
-  jlong proxy(JNIEnv* env, jstring name, jobjectArray methods);
-
-  jobject call(JNIEnv* env, jlong instance, jobject method, jobjectArray args);
+  const JavaScriptObject* proxy(JNIEnv* env, jstring name, jobjectArray methods);
 
 private:
   duk_context* m_context;
-  std::vector<JavaScriptObject*> m_proxiedObjects;
+  std::list<JavaScriptObject> m_proxiedObjects;
 };
 
 #endif // DUKTAPE_ANDROID_DUKTAPE_CONTEXT_H

--- a/duktape/src/main/jni/JavaExceptions.cpp
+++ b/duktape/src/main/jni/JavaExceptions.cpp
@@ -85,4 +85,6 @@ void queueJavaExceptionForDuktapeError(JNIEnv *env, duk_context *ctx) {
     // Not an error or no stacktrace, just convert to a string.
     env->ThrowNew(exceptionClass, duk_safe_to_string(ctx, -1));
   }
+
+  duk_pop(ctx);
 }

--- a/duktape/src/main/jni/JavaMethod.h
+++ b/duktape/src/main/jni/JavaMethod.h
@@ -35,7 +35,13 @@ public:
    * Defines a functor to use to pop a value off the Duktape stack and convert it to the required
    * Java type.
    */
-  typedef std::function<jvalue(duk_context*, JNIEnv*)> ArgumentLoader;
+  typedef std::function<jvalue(duk_context*, JNIEnv*)> JavaValuePopper;
+  /**
+   * Defines a functor to use to push a value onto the Duktape stack, unboxing and converting it to
+   * the required JavaScript type.
+   */
+  typedef std::function<duk_ret_t(duk_context*, JNIEnv*, jvalue)> JavaValuePusher;
+
   /**
    * Defines a functor to invoke the correct JNI method that will return the required Java type,
    * convert the return value to a JavaScript type and push it to the Duktape stack.  Returns the
@@ -45,8 +51,13 @@ public:
    */
   typedef std::function<duk_ret_t(duk_context*, JNIEnv*, jobject, jvalue*)> MethodBody;
 
+  // TODO: these static methods and functor types belong in their own class.
+
+  static JavaValuePopper getValuePopper(JNIEnv *env, jobject typeObject, bool forceBoxed = false);
+  static JavaValuePusher getValuePusher(JNIEnv* env, jclass type, bool forceBoxed = false);
+
 private:
-  std::vector<ArgumentLoader> m_argumentLoaders;
+  std::vector<JavaValuePopper> m_argumentLoaders;
   MethodBody m_methodBody;
 };
 

--- a/duktape/src/main/jni/JavaScriptObject.cpp
+++ b/duktape/src/main/jni/JavaScriptObject.cpp
@@ -18,21 +18,24 @@
 #include <stdexcept>
 #include "JString.h"
 #include "JavaExceptions.h"
-
-// TODO: debug instance tracking issues so we don't need to lookup by name on a call.
-#define NO_INSTANCE_VAR
+#include "JavaMethod.h"
 
 namespace {
 
 // Internal names used for properties in a proxied JavaScript object.
 // The \xff\xff part keeps the variable hidden from JavaScript (visible through C API only).
+
+// We stuff JavaScriptObject pointers into an array and attach it to the proxied instance so we are
+// able to detach our local reference to the object when it is garbage collected in the JS VM.
 const char* WRAPPER_THIS_PROP_NAME = "\xff\xffwrapper_this";
+
+JavaScriptObject::MethodBody buildMethodBody(JNIEnv* env, jobject method, const std::string& name);
 
 }
 
-JavaScriptObject::JavaScriptObject(JNIEnv* env, duk_context* context, const std::string& name,
+JavaScriptObject::JavaScriptObject(JNIEnv* env, duk_context* context, jstring name,
                                    jobjectArray methods)
-    : m_name(name)
+    : m_name(JString(env, name).str())
     , m_context(context)
     , m_instance(nullptr)
     , m_nextFinalizer(nullptr) {
@@ -42,12 +45,8 @@ JavaScriptObject::JavaScriptObject(JNIEnv* env, duk_context* context, const std:
     throw std::invalid_argument("A global JavaScript object called " + m_name + " was not found");
   }
 
-#ifdef NO_INSTANCE_VAR
-  if (!duk_is_object(m_context, -1)) {
-#else
   m_instance = duk_get_heapptr(m_context, -1);
   if (m_instance == nullptr) {
-#endif
     duk_pop_2(m_context);
     throw std::invalid_argument("JavaScript global called " + m_name + " is not an object");
   }
@@ -62,9 +61,10 @@ JavaScriptObject::JavaScriptObject(JNIEnv* env, duk_context* context, const std:
       getName = env->GetMethodID(methodClass, "getName", "()Ljava/lang/String;");
     }
 
+    // Sanity check that as of right now, the object we're proxying has a function with this name.
     const JString methodName(env, static_cast<jstring>(env->CallObjectMethod(method, getName)));
     if (!duk_get_prop_string(m_context, -1, methodName)) {
-      duk_pop_2(m_context);
+      duk_pop_3(m_context);
       throw std::runtime_error("JavaScript global " + m_name + " has no method called " +
           methodName.str());
     } else if (!duk_is_callable(m_context, -1)) {
@@ -73,14 +73,20 @@ JavaScriptObject::JavaScriptObject(JNIEnv* env, duk_context* context, const std:
           " not callable");
     }
 
-    // TODO: build a call wrapper that handles marshalling the arguments and return value.
-    //       Store it in this object.
+    try {
+      // Build a call wrapper that handles marshalling the arguments and return value.
+      m_methods.emplace(std::make_pair(env->FromReflectedMethod(method),
+                                       buildMethodBody(env, method, methodName.str())));
+    } catch (const std::invalid_argument& e) {
+      duk_pop_3(m_context);
+      throw std::invalid_argument("In proxied method \"" + m_name + "." + methodName.str() +
+                                      "\": " + e.what());
+    }
 
     // Pop the method property.
     duk_pop(m_context);
   }
 
-#ifndef NO_INSTANCE_VAR
   // Keep track of any previously registered finalizer.
   duk_get_finalizer(m_context, -1);
   m_nextFinalizer = duk_is_c_function(m_context, -1)
@@ -89,9 +95,19 @@ JavaScriptObject::JavaScriptObject(JNIEnv* env, duk_context* context, const std:
   duk_pop(m_context);
   duk_push_c_function(m_context, JavaScriptObject::finalizer, 1);
   duk_set_finalizer(m_context, -2);
-#endif
 
+  // Add 'this' to the list of pointers attached to the proxied instance.
+  // TODO: don't use an array here, just use a separate hidden property for each proxy.
+  if (!duk_has_prop_string(m_context, -1, WRAPPER_THIS_PROP_NAME)) {
+    duk_push_array(m_context);
+  } else {
+    duk_get_prop_string(m_context, -1, WRAPPER_THIS_PROP_NAME);
+  }
+
+  const duk_size_t length = duk_get_length(m_context, -1);
   duk_push_pointer(m_context, this);
+  duk_put_prop_index(m_context, -2, static_cast<duk_uarridx_t>(length));
+  // Add the array (back) to the instance.
   duk_put_prop_string(m_context, -2, WRAPPER_THIS_PROP_NAME);
 
   // Pop the global and our instance.
@@ -99,75 +115,139 @@ JavaScriptObject::JavaScriptObject(JNIEnv* env, duk_context* context, const std:
 }
 
 JavaScriptObject::~JavaScriptObject() {
-  if (m_instance) {
-    // The instance still exists - detach from it.
-    duk_push_heapptr(m_context, m_instance);
-    duk_del_prop_string(m_context, -1, WRAPPER_THIS_PROP_NAME);
+  if (!m_instance) {
+    // Instance has already been cleaned up.
+    return;
+  }
+  // The instance still exists - detach from it.
+  duk_push_global_object(m_context);
+  duk_push_heapptr(m_context, m_instance);
 
+  // Remove this pointer from the JS object's property.
+  if (duk_get_prop_string(m_context, -1, WRAPPER_THIS_PROP_NAME)) {
+    const duk_size_t length = duk_get_length(m_context, -1);
+    for (duk_uarridx_t i = 0; i < length; ++i) {
+      duk_get_prop_index(m_context, -1, i);
+
+      const void* ptr = duk_get_pointer(m_context, -1);
+      duk_pop(m_context);
+
+      if (this == ptr) {
+        // Remove this object from the array.
+        duk_del_prop_index(m_context, -1, i);
+        break;
+      }
+    }
+  }
+
+  // Pop the array (or undefined if there was none).
+  duk_pop(m_context);
+
+  if (m_nextFinalizer) {
     // Reset to the object's previous finalizer.
     duk_push_c_function(m_context, m_nextFinalizer, 1);
     duk_set_finalizer(m_context, -2);
-    duk_pop(m_context);
   }
+
+  // Pop the instance & global object.
+  duk_pop_2(m_context);
 }
 
-jobject JavaScriptObject::call(JNIEnv* env, jobject method, jobjectArray args) {
-#ifdef NO_INSTANCE_VAR
-  duk_push_global_object(m_context);
-  if (!duk_get_prop_string(m_context, -1, m_name.c_str())) {
-    duk_pop(m_context);
-    queueNullPointerException(env, "JavaScript object called " + m_name + " was not found");
-    return nullptr;
-  }
-#else
+jobject JavaScriptObject::call(JNIEnv* env, jobject method, jobjectArray args) const {
   if (m_instance == nullptr) {
-    queueNullPointerException(env, "JavaScript object " + m_name + " has been garbage collected");
+    queueDuktapeException(env, "JavaScript object " + m_name + " has been garbage collected");
     return nullptr;
   }
-  duk_push_heapptr(m_context, m_instance);
-#endif
 
-  jclass methodClass = env->GetObjectClass(method);
+  const auto methodIter = m_methods.find(env->FromReflectedMethod(method));
+  if (methodIter != m_methods.end()) {
+    return methodIter->second(env, m_context, m_instance, args);
+  }
 
+  // Failed to find the method in our map - should be impossible!
+  const jclass methodClass = env->GetObjectClass(method);
   const jmethodID getName = env->GetMethodID(methodClass, "getName", "()Ljava/lang/String;");
   const JString methodName(env, static_cast<jstring>(env->CallObjectMethod(method, getName)));
-  duk_push_string(m_context, methodName);
-
-  // TODO: put the arguments (from args) on the stack too.
-
-  jobject result;
-  if (duk_pcall_prop(m_context, -2, 0) == DUK_EXEC_SUCCESS) {
-    // TODO: handle other return types.
-    result = duk_is_null_or_undefined(m_context, -1)
-        ? nullptr
-        : env->NewStringUTF(duk_safe_to_string(m_context, -1));
-  } else {
-    queueJavaExceptionForDuktapeError(env, m_context);
-    result = nullptr;
-  }
-
-  // Pop our instance and the call's result or error.
-  duk_pop_3(m_context);
-
-  return result;
+  queueDuktapeException(env, "Could not find method " + m_name + "." + methodName.str());
+  return nullptr;
 }
 
 duk_ret_t JavaScriptObject::finalizer(duk_context* ctx) {
-  if (!duk_get_prop_string(ctx, -1, WRAPPER_THIS_PROP_NAME)) {
-    return 0;
+  // Remove this pointers from the JS object's property.
+  if (duk_get_prop_string(ctx, -1, WRAPPER_THIS_PROP_NAME)) {
+    const duk_size_t length = duk_get_length(ctx, -1);
+    for (duk_uarridx_t i = 0; i < length; ++i) {
+      duk_get_prop_index(ctx, -1, i);
+
+      JavaScriptObject* obj = reinterpret_cast<JavaScriptObject*>(duk_get_pointer(ctx, -1));
+      if (obj && obj->m_instance) {
+        // Null out the instance pointer - it's been garbage collected!
+        obj->m_instance = nullptr;
+
+        if (obj->m_nextFinalizer) {
+          // Continue with the next finalizer in the chain.
+          obj->m_nextFinalizer(ctx);
+        }
+      }
+      duk_pop(ctx);
+    }
   }
 
-  JavaScriptObject* obj = reinterpret_cast<JavaScriptObject*>(duk_require_pointer(ctx, -1));
+  // Pop the array (or undefined if there was none).
   duk_pop(ctx);
 
-  duk_del_prop_string(ctx, -1, WRAPPER_THIS_PROP_NAME);
-
-  // Null out the instance pointer - it's been garbage collected!
-  obj->m_instance = nullptr;
-
-  if (obj->m_nextFinalizer) {
-    // Continue with the next finalizer in the chain.
-    obj->m_nextFinalizer(ctx);
-  }
   return 0;
 }
+
+namespace {
+
+JavaScriptObject::MethodBody buildMethodBody(JNIEnv* env, jobject method,
+                                             const std::string& methodName) {
+  const jclass methodClass = env->GetObjectClass(method);
+
+  const jmethodID getReturnType =
+      env->GetMethodID(methodClass, "getReturnType", "()Ljava/lang/Class;");
+  jobject returnType = env->CallObjectMethod(method, getReturnType);
+  const auto returnValueLoader = JavaMethod::getValuePopper(env, returnType, true);
+
+  const jmethodID getParameterTypes =
+      env->GetMethodID(methodClass, "getParameterTypes", "()[Ljava/lang/Class;");
+  jobjectArray parameterTypes =
+      static_cast<jobjectArray>(env->CallObjectMethod(method, getParameterTypes));
+  const jsize numArgs = env->GetArrayLength(parameterTypes);
+
+  std::vector<JavaMethod::JavaValuePusher> argumentLoaders(numArgs);
+  for (jsize i = 0; i < numArgs; ++i) {
+    auto parameterType = env->GetObjectArrayElement(parameterTypes, i);
+    argumentLoaders[i] = JavaMethod::getValuePusher(env, static_cast<jclass>(parameterType), true);
+  }
+
+  return [methodName, returnValueLoader, argumentLoaders]
+      (JNIEnv* jniEnv, duk_context* ctx, void* instance, jobjectArray args) {
+    duk_push_global_object(ctx);
+    // Set up the call - push the object, method name, and arguments onto the stack.
+    duk_push_heapptr(ctx, instance);
+    duk_push_string(ctx, methodName.c_str());
+    const jsize numArguments = args != nullptr ? jniEnv->GetArrayLength(args) : 0;
+    jvalue arg;
+    for (jsize i = 0; i < numArguments; ++i) {
+      arg.l = jniEnv->GetObjectArrayElement(args, i);
+      argumentLoaders[i](ctx, jniEnv, arg);
+    }
+
+    jobject result;
+    if (duk_pcall_prop(ctx, -2 - numArguments, numArguments) == DUK_EXEC_SUCCESS) {
+      result = returnValueLoader(ctx, jniEnv).l;
+    } else {
+      queueJavaExceptionForDuktapeError(jniEnv, ctx);
+      result = nullptr;
+    }
+
+    // Pop the instance and global object.
+    duk_pop_2(ctx);
+
+    return result;
+  };
+}
+
+} // anonymous namespace

--- a/tests/src/androidTest/java/com/squareup/duktape/DuktapeBindTest.java
+++ b/tests/src/androidTest/java/com/squareup/duktape/DuktapeBindTest.java
@@ -319,7 +319,7 @@ public final class DuktapeBindTest {
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected).hasMessage(
-          "In bound method \"value.set\": Unsupported parameter type class java.util.Date");
+          "In bound method \"value.set\": Unsupported Java type class java.util.Date");
     }
   }
 


### PR DESCRIPTION
- use Duktape heap pointers to track proxied objects rather than names.
- track JavaScriptObject (proxy) by pointers through JNI, not indexes.
- proxied methods support the same argument and return types as bind
  (bool/Boolean/int/Integer/double/Double/String).
- move some C++ exception handlers/converters into the top-level jni interface.