### PR TITLE
Create a stack checker used in debug builds.

### DIFF
--- a/duktape/build.gradle
+++ b/duktape/build.gradle
@@ -18,8 +18,15 @@ model {
     buildTypes {
       release {
         ndk {
-          CFlags.addAll(['-Os', '-fomit-frame-pointer'])
-          cppFlags.addAll(['-Os', '-fomit-frame-pointer'])
+          CFlags.addAll(['-Os', '-fomit-frame-pointer', '-DNDEBUG'])
+          cppFlags.addAll(['-Os', '-fomit-frame-pointer', '-DNDEBUG'])
+        }
+      }
+      debug {
+        ndk {
+          debuggable true
+          CFlags.addAll(['-g'])
+          cppFlags.addAll(['-g'])
         }
       }
     }

--- a/duktape/src/main/jni/JavaExceptions.cpp
+++ b/duktape/src/main/jni/JavaExceptions.cpp
@@ -57,11 +57,13 @@ void queueJavaExceptionForDuktapeError(JNIEnv *env, duk_context *ctx) {
   jclass exceptionClass = env->FindClass("com/squareup/duktape/DuktapeException");
 
   // If it's a Duktape error object, try to pull out the full stacktrace.
-  if (duk_is_error(ctx, -1) && duk_get_prop_string(ctx, -1, "stack")) {
+  if (duk_is_error(ctx, -1) && duk_has_prop_string(ctx, -1, "stack")) {
+    duk_get_prop_string(ctx, -1, "stack");
     const char* stack = duk_safe_to_string(ctx, -1);
 
     // Is there an exception thrown from a Java method?
-    if (duk_get_prop_string(ctx, -2, JAVA_EXCEPTION_PROP_NAME)) {
+    if (duk_has_prop_string(ctx, -2, JAVA_EXCEPTION_PROP_NAME)) {
+      duk_get_prop_string(ctx, -2, JAVA_EXCEPTION_PROP_NAME);
       jthrowable ex = static_cast<jthrowable>(duk_get_pointer(ctx, -1));
 
       // add the Duktape JavaScript stack to this exception.

--- a/duktape/src/main/jni/StackChecker.h
+++ b/duktape/src/main/jni/StackChecker.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef DUKTAPE_ANDROID_STACK_CHECKER_H
+#define DUKTAPE_ANDROID_STACK_CHECKER_H
+
+#include "duktape.h"
+#include <string>
+#include <stdexcept>
+
+/**
+ * Throws an exception and aborts the process if the Duktape stack has a different number of
+ * elements at the end of the C++ scope than where the object was constructed.  This will show a
+ * trace and Duktape stack details in logcat when running in the debugger.  Use CHECK_STACK()
+ * below for a convenient way to add stack validation to debug builds only.
+ */
+class StackChecker {
+public:
+  StackChecker(duk_context* ctx)
+    : m_context(ctx)
+    , m_top(duk_get_top(m_context)) {
+  }
+  ~StackChecker() {
+    if (m_top == duk_get_top(m_context)) {
+      return;
+    }
+    const auto actual = duk_get_top(m_context);
+    duk_push_context_dump(m_context);
+    throw stack_error(m_top, actual, duk_get_string(m_context, -1));
+  }
+
+private:
+  struct stack_error : public std::runtime_error {
+    stack_error(duk_idx_t expected, duk_idx_t actual, const std::string& stack)
+      : std::runtime_error("expected " + std::to_string(expected) +
+                           ", actual " + std::to_string(actual) +
+                           " - stack " + stack) {
+    }
+  };
+
+  duk_context* m_context;
+  const duk_idx_t m_top;
+};
+
+// TODO: always run unit tests with a debug version of this library.
+#ifdef NDEBUG
+#define CHECK_STACK(ctx) ((void)0)
+#else
+#define CHECK_STACK(ctx) const StackChecker _(ctx)
+#endif
+
+#endif //DUKTAPE_ANDROID_STACK_CHECKER_H

--- a/tests/src/androidTest/java/com/squareup/duktape/DuktapeTest.java
+++ b/tests/src/androidTest/java/com/squareup/duktape/DuktapeTest.java
@@ -16,13 +16,11 @@
 package com.squareup.duktape;
 
 import android.support.test.runner.AndroidJUnit4;
-
+import java.util.TimeZone;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.util.TimeZone;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;


### PR DESCRIPTION
- throws/aborts when the stack isn't what we expect
- shows the C++ callstack and what was on the duktape stack in logcat