### PR TITLE
Add compiler flags to hide symbols for unexported functions.

### DIFF
--- a/duktape/build.gradle
+++ b/duktape/build.gradle
@@ -18,8 +18,8 @@ model {
     buildTypes {
       release {
         ndk {
-          CFlags.addAll(['-Os', '-fomit-frame-pointer', '-DNDEBUG'])
-          cppFlags.addAll(['-Os', '-fomit-frame-pointer', '-DNDEBUG'])
+          CFlags.addAll(['-Os', '-fomit-frame-pointer', '-DNDEBUG', '-fvisibility=hidden'])
+          cppFlags.addAll(['-Os', '-fomit-frame-pointer', '-DNDEBUG', '-fvisibility=hidden'])
         }
       }
       debug {


### PR DESCRIPTION
```
$ diff -y before.txt after.txt
608304 duktape/build/intermediates/binaries/release/lib/arm64 |	596016 duktape/build/intermediates/binaries/release/lib/arm64
452248 duktape/build/intermediates/binaries/release/lib/armea |	439960 duktape/build/intermediates/binaries/release/lib/armea
390816 duktape/build/intermediates/binaries/release/lib/armea |	378528 duktape/build/intermediates/binaries/release/lib/armea
897836 duktape/build/intermediates/binaries/release/lib/mips/ |	897812 duktape/build/intermediates/binaries/release/lib/mips/
949736 duktape/build/intermediates/binaries/release/lib/mips6 |	937400 duktape/build/intermediates/binaries/release/lib/mips6
669324 duktape/build/intermediates/binaries/release/lib/x86/l |	661132 duktape/build/intermediates/binaries/release/lib/x86/l
637280 duktape/build/intermediates/binaries/release/lib/x86_6 |	620896 duktape/build/intermediates/binaries/release/lib/x86_6
7215360 duktape/build/intermediates/binaries/release/obj/arm6 |	7203288 duktape/build/intermediates/binaries/release/obj/arm6
6558736 duktape/build/intermediates/binaries/release/obj/arme |	6546384 duktape/build/intermediates/binaries/release/obj/arme
6445036 duktape/build/intermediates/binaries/release/obj/arme |	6432756 duktape/build/intermediates/binaries/release/obj/arme
6890920 duktape/build/intermediates/binaries/release/obj/mips |	6890896 duktape/build/intermediates/binaries/release/obj/mips
11550336 duktape/build/intermediates/binaries/release/obj/mip |	11538000 duktape/build/intermediates/binaries/release/obj/mip
6880020 duktape/build/intermediates/binaries/release/obj/x86/ |	6871828 duktape/build/intermediates/binaries/release/obj/x86/
7089288 duktape/build/intermediates/binaries/release/obj/x86_ |	7072904 duktape/build/intermediates/binaries/release/obj/x86_
608304 duktape/build/intermediates/bundles/release/jni/arm64- |	596016 duktape/build/intermediates/bundles/release/jni/arm64-
452248 duktape/build/intermediates/bundles/release/jni/armeab |	439960 duktape/build/intermediates/bundles/release/jni/armeab
390816 duktape/build/intermediates/bundles/release/jni/armeab |	378528 duktape/build/intermediates/bundles/release/jni/armeab
897836 duktape/build/intermediates/bundles/release/jni/mips/l |	897812 duktape/build/intermediates/bundles/release/jni/mips/l
949736 duktape/build/intermediates/bundles/release/jni/mips64 |	937400 duktape/build/intermediates/bundles/release/jni/mips64
669324 duktape/build/intermediates/bundles/release/jni/x86/li |	661132 duktape/build/intermediates/bundles/release/jni/x86/li
637280 duktape/build/intermediates/bundles/release/jni/x86_64 |	620896 duktape/build/intermediates/bundles/release/jni/x86_64
608304 duktape/build/intermediates/transforms/mergeJniLibs/re |	596016 duktape/build/intermediates/transforms/mergeJniLibs/re
452248 duktape/build/intermediates/transforms/mergeJniLibs/re |	439960 duktape/build/intermediates/transforms/mergeJniLibs/re
390816 duktape/build/intermediates/transforms/mergeJniLibs/re |	378528 duktape/build/intermediates/transforms/mergeJniLibs/re
897836 duktape/build/intermediates/transforms/mergeJniLibs/re |	897812 duktape/build/intermediates/transforms/mergeJniLibs/re
949736 duktape/build/intermediates/transforms/mergeJniLibs/re |	937400 duktape/build/intermediates/transforms/mergeJniLibs/re
669324 duktape/build/intermediates/transforms/mergeJniLibs/re |	661132 duktape/build/intermediates/transforms/mergeJniLibs/re
637280 duktape/build/intermediates/transforms/mergeJniLibs/re |	620896 duktape/build/intermediates/transforms/mergeJniLibs/re
```