### PR TITLE
Allow arguments of type Object in function calls.

### DIFF
--- a/duktape/src/main/jni/duktape-jni.cpp
+++ b/duktape/src/main/jni/duktape-jni.cpp
@@ -128,6 +128,8 @@ Java_com_squareup_duktape_Duktape_call(JNIEnv *env, jclass type, jlong context, 
 
   try {
     return object->call(env, method, args);
+  } catch (const std::invalid_argument& e) {
+    queueIllegalArgumentException(env, e.what());
   } catch (const std::runtime_error& e) {
     queueDuktapeException(env, e.what());
   }

--- a/duktape/src/main/jni/java/JavaType.h
+++ b/duktape/src/main/jni/java/JavaType.h
@@ -26,6 +26,7 @@
  */
 class JavaType {
 public:
+  virtual ~JavaType() = default;
   /** Pops a {@code jvalue} from the Duktape stack in {@code ctx}. */
   virtual jvalue pop(duk_context* ctx, JNIEnv*) const = 0;
   /**

--- a/tests/src/androidTest/java/com/squareup/duktape/DuktapeGetTest.java
+++ b/tests/src/androidTest/java/com/squareup/duktape/DuktapeGetTest.java
@@ -276,4 +276,34 @@ public class DuktapeGetTest {
     assertThat(printer.call(true, 42, 2.718281828459))
         .isEqualTo("boolean: true, int: 42, double: 2.718281828459");
   }
+
+  interface TestMultipleObjectArgs {
+    Object print(Object b, Object i, Object d);
+  }
+
+  @Test public void callProxyMultipleObjectArgs() {
+    duktape.evaluate("var printer = {\n" +
+        "  print: function(b, i, d) {\n" +
+        "    return 'boolean: ' + b + ', int: ' + i + ', double: ' + d;\n" +
+        "  }\n" +
+        "};");
+    TestMultipleObjectArgs printer = duktape.get("printer", TestMultipleObjectArgs.class);
+    assertThat(printer.print(true, 42, 2.718281828459))
+        .isEqualTo("boolean: true, int: 42, double: 2.718281828459");
+  }
+
+  @Test public void passUnsupportedTypeAsObjectFails() {
+    duktape.evaluate("var printer = {\n" +
+        "  print: function(b, i, d) {\n" +
+        "    return 'boolean: ' + b + ', int: ' + i + ', double: ' + d;\n" +
+        "  }\n" +
+        "};");
+    TestMultipleObjectArgs printer = duktape.get("printer", TestMultipleObjectArgs.class);
+    try {
+      printer.print(true, 42, new Date());
+      fail();
+    } catch (IllegalArgumentException expected) {
+      assertThat(expected).hasMessage("Unsupported Java type class java.util.Date");
+    }
+  }
 }


### PR DESCRIPTION
- Type checking for these is done at runtime.