### PR TITLE
Fix type checking when returning values from JS.

### DIFF
--- a/duktape/src/main/jni/duktape-jni.cpp
+++ b/duktape/src/main/jni/duktape-jni.cpp
@@ -75,7 +75,9 @@ Java_com_squareup_duktape_Duktape_evaluate__JLjava_lang_String_2Ljava_lang_Strin
   }
   try {
     return duktape->evaluate(env, code, fname);
-  } catch (const std::runtime_error& e) {
+  } catch (const std::invalid_argument& e) {
+    queueIllegalArgumentException(env, e.what());
+  } catch (const std::exception& e) {
     queueDuktapeException(env, e.what());
   }
   return nullptr;
@@ -91,7 +93,9 @@ Java_com_squareup_duktape_Duktape_set(JNIEnv *env, jclass type, jlong context, j
   }
   try {
     duktape->set(env, name, object, methods);
-  } catch (const std::runtime_error& e) {
+  } catch (const std::invalid_argument& e) {
+    queueIllegalArgumentException(env, e.what());
+  } catch (const std::exception& e) {
     queueDuktapeException(env, e.what());
   }
 }
@@ -109,7 +113,7 @@ Java_com_squareup_duktape_Duktape_get(JNIEnv *env, jclass type, jlong context, j
     return reinterpret_cast<jlong>(duktape->get(env, name, methods));
   } catch (const std::invalid_argument& e) {
     queueIllegalArgumentException(env, e.what());
-  } catch (const std::runtime_error& e) {
+  } catch (const std::exception& e) {
     queueDuktapeException(env, e.what());
   }
   return 0L;
@@ -135,7 +139,7 @@ Java_com_squareup_duktape_Duktape_call(JNIEnv *env, jclass type, jlong context, 
     return object->call(env, method, args);
   } catch (const std::invalid_argument& e) {
     queueIllegalArgumentException(env, e.what());
-  } catch (const std::runtime_error& e) {
+  } catch (const std::exception& e) {
     queueDuktapeException(env, e.what());
   }
   return nullptr;

--- a/duktape/src/main/jni/java/JavaMethod.cpp
+++ b/duktape/src/main/jni/java/JavaMethod.cpp
@@ -60,7 +60,7 @@ duk_ret_t JavaMethod::invoke(duk_context* ctx, JNIEnv* env, jobject javaThis) co
   // Load the arguments off the stack and convert to Java types.
   // Note we're going backwards since the last argument is at the top of the stack.
   for (ssize_t i = m_argumentLoaders.size() - 1; i >= 0; --i) {
-    args[i] = m_argumentLoaders[i]->pop(ctx, env);
+    args[i] = m_argumentLoaders[i]->pop(ctx, env, true);
   }
 
   return m_methodBody(ctx, env, javaThis, args.data());

--- a/tests/src/main/java/com/squareup/duktape/tests/OctaneActivity.java
+++ b/tests/src/main/java/com/squareup/duktape/tests/OctaneActivity.java
@@ -65,7 +65,7 @@ public final class OctaneActivity extends Activity {
         }
         evaluateAsset(duktape, "octane.js");
 
-        String results = duktape.evaluate("getResults();");
+        String results = (String) duktape.evaluate("getResults();");
         output.append('\n').append(results);
       } catch (IOException e) {
         StringWriter sw = new StringWriter();


### PR DESCRIPTION
- duk_require_XXX only really works inside of a script execution,
  so when we call out to JS and pop the result off the stack from
  outside the execution, we need to check the type.
- Make all results Object, and let Java take care of it.  The only
  exception is that JS has no Integer, so we have to truncate
  Doubles as needed.