### PR TITLE
evaluate returns null if result type unsupported

### DIFF
--- a/duktape/src/main/java/com/squareup/duktape/Duktape.java
+++ b/duktape/src/main/java/com/squareup/duktape/Duktape.java
@@ -50,9 +50,9 @@ public final class Duktape implements Closeable {
   }
 
   /**
-   * Evaluate {@code script} and return any result. {@code fileName} will be used in error
+   * Evaluate {@code script} and return a result. {@code fileName} will be used in error
    * reporting. Note that the result must be one of the supported Java types or the call will
-   * throw a {@link DuktapeException}.
+   * return null.
    *
    * @throws DuktapeException if there is an error evaluating the script.
    */
@@ -60,8 +60,8 @@ public final class Duktape implements Closeable {
     return evaluate(context, script, fileName);
   }
   /**
-   * Evaluate {@code script} and return any result. Note that the result must be one of the
-   * supported Java types or the call will throw a {@link DuktapeException}.
+   * Evaluate {@code script} and return a result. Note that the result must be one of the
+   * supported Java types or the call will return null.
    *
    * @throws DuktapeException if there is an error evaluating the script.
    */

--- a/duktape/src/main/jni/DuktapeContext.cpp
+++ b/duktape/src/main/jni/DuktapeContext.cpp
@@ -133,6 +133,13 @@ jobject DuktapeContext::evaluate(JNIEnv* env, jstring code, jstring fname) const
     return nullptr;
   }
 
+  const int supportedTypeMask = DUK_TYPE_MASK_BOOLEAN | DUK_TYPE_MASK_NUMBER | DUK_TYPE_MASK_STRING;
+  if (!duk_check_type_mask(m_context, -1, supportedTypeMask)) {
+    // The result is an unsupported type, undefined, or null.
+    duk_pop(m_context);
+    return nullptr;
+  }
+
   return m_objectType->pop(m_context, env, false).l;
 }
 

--- a/tests/src/androidTest/java/com/squareup/duktape/DuktapeGetTest.java
+++ b/tests/src/androidTest/java/com/squareup/duktape/DuktapeGetTest.java
@@ -125,7 +125,7 @@ public class DuktapeGetTest {
     TestInterface proxy = duktape.get("value", TestInterface.class);
 
     // Now replace the proxied object with a new global.
-    duktape.evaluate("value = { getValue: function() { return '7471111'; } }; null;");
+    duktape.evaluate("value = { getValue: function() { return '7471111'; } };");
 
     try {
       // Calls to the old object fail.
@@ -145,7 +145,7 @@ public class DuktapeGetTest {
     duktape.evaluate("var value = { getValue: function() { return '8675309'; } };");
 
     TestInterface proxy = duktape.get("value", TestInterface.class);
-    duktape.evaluate("value.getValue = function() { return '7471111'; }; null;");
+    duktape.evaluate("value.getValue = function() { return '7471111'; };");
 
     String v = proxy.getValue();
     assertThat(v).isEqualTo("7471111");


### PR DESCRIPTION
- The last statement of a script ends up being the return value, which causes problems in some cases when we try to marshal it back to Java. e.g. evaluating "foo.bar = function() { return 3; }" will return a function object and cause an IllegalArgumentException.