### PR TITLE
Add support for new Date parsing of common formats

### DIFF
--- a/duktape/src/main/jni/duktape-jni.cpp
+++ b/duktape/src/main/jni/duktape-jni.cpp
@@ -46,10 +46,47 @@ duk_int_t android__get_local_tzoffset(duk_double_t time) {
                                   time);
 }
 
+/**
+ * Overload the default Duktape parser (which only does "%c"/ISO8601) to handle other date formats
+ * that tend to appear in JavaScript docs around parsing dates.
+ */
+duk_bool_t android__date_parse_string(duk_context* ctx, const char* str) {
+  // Ordered by likelihood (ideally %c/ISO8601 is the format we're given).
+  static const char* dateFormats[] = {
+      "%c",             // 2015-03-25T23:45:12
+      "%Y/%m/%d %T",    // 2015/03/25 23:45:12
+      "%Y/%m/%d",
+      "%m/%d/%Y %T",    // 03/25/2015 23:45:12
+      "%m/%d/%Y",
+      "%b %d %Y %T",    // Mar[ch] 25 2015 23:45:12
+      "%b %d %Y",
+      "%d %b %Y %T",    // 25 Mar[ch] 2015 23:45:12
+      "%d %b %Y",
+      "%a %b %d %Y %T", // Wed[nesday] Mar[ch] 25 2015 23:45:12
+      "%a %b %d %Y",
+  };
+  tm tm;
+  int timezoneOffset = android__get_local_tzoffset(0);
+  for (const auto dateFormat : dateFormats) {
+    memset(&tm, 0, sizeof(tm));
+    if (!strptime(str, dateFormat, &tm)) {
+      // No dice.
+      continue;
+    }
+    tm.tm_isdst = -1; // Not set by strptime - unknown if DST.
+    const auto t = timegm(&tm);
+    if (t >= 0) {
+      duk_push_number(ctx, (t - timezoneOffset) * 1000.0);
+      return true;
+    }
+  }
+  return false;
+}
+
 JNIEXPORT jlong JNICALL
 Java_com_squareup_duktape_Duktape_createContext(JNIEnv* env, jclass type) {
-  static std::once_flag initDuktapeClass;
-  std::call_once(initDuktapeClass, initialize, std::ref(env), type);
+  static std::once_flag initialized;
+  std::call_once(initialized, initialize, std::ref(env), type);
 
   JavaVM* javaVM;
   env->GetJavaVM(&javaVM);

--- a/duktape/src/main/jni/duktape/duk_custom.h
+++ b/duktape/src/main/jni/duktape/duk_custom.h
@@ -1,1 +1,2 @@
 #define DUK_USE_DATE_GET_LOCAL_TZOFFSET android__get_local_tzoffset
+#define DUK_USE_DATE_PARSE_STRING android__date_parse_string

--- a/tests/src/androidTest/java/com/squareup/duktape/DuktapeTest.java
+++ b/tests/src/androidTest/java/com/squareup/duktape/DuktapeTest.java
@@ -91,4 +91,48 @@ public final class DuktapeTest {
       TimeZone.setDefault(original);
     }
   }
+
+  @Test public void parseDates() {
+    TimeZone original = TimeZone.getDefault();
+    try {
+      TimeZone.setDefault(TimeZone.getTimeZone("GMT+02:00"));
+      assertThat(duktape.evaluate("new Date('2015-03-25').toString();"))
+          .isEqualTo("2015-03-25 02:00:00.000+02:00");
+      assertThat(duktape.evaluate("new Date('03/25/2015').toString();"))
+          .isEqualTo("2015-03-25 00:00:00.000+02:00");
+      assertThat(duktape.evaluate("new Date('2015/03/25').toString();"))
+          .isEqualTo("2015-03-25 00:00:00.000+02:00");
+      assertThat(duktape.evaluate("new Date('Mar 25 2015').toString();"))
+          .isEqualTo("2015-03-25 00:00:00.000+02:00");
+      assertThat(duktape.evaluate("new Date('25 Mar 2015').toString();"))
+          .isEqualTo("2015-03-25 00:00:00.000+02:00");
+      assertThat(duktape.evaluate("new Date('Wednesday March 25 2015').toString();"))
+          .isEqualTo("2015-03-25 00:00:00.000+02:00");
+    } finally {
+      TimeZone.setDefault(original);
+    }
+  }
+
+  @Test public void parseDateAndTime() {
+    TimeZone original = TimeZone.getDefault();
+    try {
+      TimeZone.setDefault(TimeZone.getTimeZone("GMT-02:00"));
+      assertThat(duktape.evaluate("new Date('2015-03-25T23:45:12').toString();"))
+          .isEqualTo("2015-03-25 21:45:12.000-02:00");
+      assertThat(duktape.evaluate("new Date('2015-03-25T23:45:12-02:00').toString();"))
+          .isEqualTo("2015-03-25 23:45:12.000-02:00");
+      assertThat(duktape.evaluate("new Date('03/25/2015 23:45:12').toString();"))
+          .isEqualTo("2015-03-25 23:45:12.000-02:00");
+      assertThat(duktape.evaluate("new Date('2015/03/25 23:45:12').toString();"))
+          .isEqualTo("2015-03-25 23:45:12.000-02:00");
+      assertThat(duktape.evaluate("new Date('Mar 25 2015 23:45:12').toString();"))
+          .isEqualTo("2015-03-25 23:45:12.000-02:00");
+      assertThat(duktape.evaluate("new Date('25 Mar 2015 23:45:12').toString();"))
+          .isEqualTo("2015-03-25 23:45:12.000-02:00");
+      assertThat(duktape.evaluate("new Date('Wednesday March 25 2015 23:45:12').toString();"))
+          .isEqualTo("2015-03-25 23:45:12.000-02:00");
+    } finally {
+      TimeZone.setDefault(original);
+    }
+  }
 }


### PR DESCRIPTION
- some extra possible formats as mentioned in various JS docs for "new Date('my date')".
- please continue to prefer ISO8601 whenever possible.