### PR TITLE
Update gradle build script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,17 +1,21 @@
+ext {
+  compileSdkVersion = 26
+  buildToolsVersion = '26.0.2'
+  buildGradleVersion = '3.0.1'
+}
+
 allprojects {
   buildscript {
     repositories {
       jcenter()
       google()
     }
+    dependencies {
+      classpath "com.android.tools.build:gradle:$buildGradleVersion"
+    }
   }
   repositories {
     jcenter()
     google()
   }
-}
-
-ext {
-  compileSdkVersion = 26
-  buildToolsVersion = '26.0.2'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ ext {
   compileSdkVersion = 26
   buildToolsVersion = '26.0.2'
   buildGradleVersion = '3.0.1'
+  ndkAbiFilters = ['x86', 'x86_64', 'armeabi', 'armeabi-v7a', 'arm64-v8a', 'mips', 'mips64']
 }
 
 allprojects {

--- a/duktape/build.gradle
+++ b/duktape/build.gradle
@@ -10,7 +10,7 @@ android {
     versionCode 1
     versionName "1.0"
     ndk {
-      abiFilters 'x86', 'x86_64', 'armeabi', 'armeabi-v7a', 'arm64-v8a', 'mips', 'mips64'
+      abiFilters(*rootProject.ext.ndkAbiFilters)
     }
     externalNativeBuild {
       cmake {

--- a/duktape/build.gradle
+++ b/duktape/build.gradle
@@ -1,9 +1,3 @@
-buildscript {
-  dependencies {
-    classpath 'com.android.tools.build:gradle:3.0.1'
-  }
-}
-
 apply plugin: 'com.android.library'
 
 android {

--- a/duktape/build.gradle
+++ b/duktape/build.gradle
@@ -47,7 +47,7 @@ android {
 }
 
 dependencies {
-  compile 'com.android.support:support-annotations:27.1.0'
+  implementation 'com.android.support:support-annotations:27.1.0'
 }
 
 task sourcesJar(type: Jar) {

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -2,12 +2,6 @@ import com.android.build.gradle.internal.tasks.AndroidTestTask
 
 apply plugin: 'com.android.application'
 
-buildscript {
-  dependencies {
-    classpath 'com.android.tools.build:gradle:3.0.1'
-  }
-}
-
 android {
   compileSdkVersion rootProject.ext.compileSdkVersion
   buildToolsVersion rootProject.ext.buildToolsVersion

--- a/tests/build.gradle
+++ b/tests/build.gradle
@@ -25,15 +25,15 @@ android {
 }
 
 dependencies {
-  compile project(':duktape')
-  androidTestCompile project(path: ':duktape')
-  compile 'com.squareup.okio:okio:1.14.0'
+  implementation project(':duktape')
+  androidTestImplementation project(path: ':duktape')
+  implementation 'com.squareup.okio:okio:1.14.0'
 
-  androidTestCompile 'com.android.support.test:runner:1.0.1'
-  androidTestCompile 'com.google.truth:truth:0.39'
+  androidTestImplementation 'com.android.support.test:runner:1.0.1'
+  androidTestImplementation 'com.google.truth:truth:0.39'
 
   // Force tests to use the same version of support-annotations as our Duktape artifact.
-  androidTestCompile 'com.android.support:support-annotations:27.1.0'
+  androidTestImplementation 'com.android.support:support-annotations:27.1.0'
 }
 
 tasks.withType(AndroidTestTask) { task ->


### PR DESCRIPTION
Centralized build gradle version and NDK abi filter.

This allow us to use ':duktape-android:duktape' as subproject with own configuration like newer gradle build version and custom ABI filter for NDK r17+ (see https://developer.android.com/studio/build/configure-apk-splits#configure-abi-split).

All builds and tests passed on my local machine.